### PR TITLE
State machine testing merge

### DIFF
--- a/SW4STM32/BellaLui/.cproject
+++ b/SW4STM32/BellaLui/.cproject
@@ -51,7 +51,7 @@
                             							
                             <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.runtimelibrary_c.1836509258" name="Runtime library" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.runtimelibrary_c" useByScannerDiscovery="true" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.runtimelibrary_c.value.nano_c" valueType="enumerated"/>
                             							
-                            <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.nanoprintffloat.964666790" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.nanoprintffloat" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+                            <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.nanoprintffloat.964666790" name="Use float with printf from newlib-nano (-u _printf_float)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.nanoprintffloat" useByScannerDiscovery="false" value="true" valueType="boolean"/>
                             							
                             <targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.targetplatform.926425231" isAbstract="false" osList="all" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.targetplatform"/>
                             							
@@ -901,9 +901,9 @@
             		
         </cconfiguration>
         		
-        <cconfiguration id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.2009857519">
+        <cconfiguration id="cdt.managedbuild.config.gnu.cross.exe.debug.1136125961">
             			
-            <storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.2009857519" moduleId="org.eclipse.cdt.core.settings" name="Testing">
+            <storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.config.gnu.cross.exe.debug.1136125961" moduleId="org.eclipse.cdt.core.settings" name="Testing">
                 				
                 <externalSettings/>
                 				
@@ -913,13 +913,13 @@
                     					
                     <extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
                     					
-                    <extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
-                    					
                     <extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
                     					
-                    <extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
-                    					
                     <extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+                    					
+                    <extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+                    					
+                    <extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
                     				
                 </extensions>
                 			
@@ -927,53 +927,91 @@
             			
             <storageModule moduleId="cdtBuildSystem" version="4.0.0">
                 				
-                <configuration artifactExtension="" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" cleanCommand="rm -rf" description="" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.2009857519" name="Testing" parent="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug" prebuildStep="${workspace_loc:/${ProjName}/Test/lib/buildgtest.sh}">
+                <configuration artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" cleanCommand="rm -rf" description="" id="cdt.managedbuild.config.gnu.cross.exe.debug.1136125961" name="Testing" parent="cdt.managedbuild.config.gnu.cross.exe.debug" prebuildStep="${workspace_loc:/${ProjName}/Test/lib/buildgtest.sh}">
                     					
-                    <folderInfo id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.2009857519." name="/" resourcePath="">
+                    <folderInfo id="cdt.managedbuild.config.gnu.cross.exe.debug.1136125961." name="/" resourcePath="">
                         						
-                        <toolChain id="com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.exe.debug.1261132260" name="MCU ARM GCC" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.toolchain.exe.debug">
+                        <toolChain id="cdt.managedbuild.toolchain.gnu.cross.exe.debug.108453450" name="Cross GCC" nonInternalBuilderId="cdt.managedbuild.builder.gnu.cross" superClass="cdt.managedbuild.toolchain.gnu.cross.exe.debug">
                             							
-                            <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_mcu.1111085854" name="Mcu" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_mcu" useByScannerDiscovery="true"/>
+                            <targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.1686774324" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
                             							
-                            <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_board.888471973" name="Board" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.option.target_board" useByScannerDiscovery="false"/>
+                            <builder buildPath="${workspace_loc:/BellaLui}/Test" id="cdt.managedbuild.builder.gnu.cross.1043669086" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross"/>
                             							
-                            <targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.targetplatform.212701051" isAbstract="false" osList="all" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.targetplatform"/>
-                            							
-                            <builder buildPath="${workspace_loc:/BellaLui}/Testing" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.builder.1531558271" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.builder"/>
-                            							
-                            <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.1895107469" name="MCU GCC Assembler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler">
+                            <tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.1613999135" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
                                 								
-                                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel.727990748" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.option.debuglevel.value.g3" valueType="enumerated"/>
+                                <option defaultValue="gnu.c.optimization.level.none" id="gnu.c.compiler.option.optimization.level.1725541176" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" valueType="enumerated"/>
                                 								
-                                <inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.input.892151308" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.assembler.input"/>
+                                <option defaultValue="gnu.c.debugging.level.max" id="gnu.c.compiler.option.debugging.level.1541227338" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" valueType="enumerated"/>
+                                								
+                                <option id="gnu.c.compiler.option.dialect.std.664607426" name="Language standard" superClass="gnu.c.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.c.compiler.dialect.c11" valueType="enumerated"/>
+                                								
+                                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.1363765494" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+                                    									
+                                    <listOptionValue builtIn="false" value="TESTING"/>
+                                    								
+                                </option>
+                                								
+                                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.435789841" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+                                    									
+                                    <listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Application/HostBoard/Inc}&quot;"/>
+                                    									
+                                    <listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Test/googletest/googlemock/include}&quot;"/>
+                                    									
+                                    <listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Test/googletest/googletest/include}&quot;"/>
+                                    								
+                                </option>
+                                								
+                                <inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.169481984" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
                                 							
                             </tool>
                             							
-                            <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.116598407" name="MCU GCC Compiler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler">
+                            <tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.51403174" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler">
                                 								
-                                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel.1763885714" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.debuglevel.value.g3" valueType="enumerated"/>
+                                <option id="gnu.cpp.compiler.option.optimization.level.1068428484" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.none" valueType="enumerated"/>
                                 								
-                                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level.654019176" name="Optimization level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.optimization.level" useByScannerDiscovery="false"/>
+                                <option defaultValue="gnu.cpp.compiler.debugging.level.max" id="gnu.cpp.compiler.option.debugging.level.1376471531" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" valueType="enumerated"/>
                                 								
-                                <inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.2013690331" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c"/>
+                                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.compiler.option.preprocessor.def.1961830004" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
+                                    									
+                                    <listOptionValue builtIn="false" value="TESTING"/>
+                                    								
+                                </option>
+                                								
+                                <option id="gnu.cpp.compiler.option.dialect.std.1211479123" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++1y" valueType="enumerated"/>
+                                								
+                                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.compiler.option.include.paths.1113167372" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+                                    									
+                                    <listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Application/HostBoard/Inc}&quot;"/>
+                                    									
+                                    <listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Test/googletest/googlemock/include}&quot;"/>
+                                    									
+                                    <listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Test/googletest/googletest/include}&quot;"/>
+                                    								
+                                </option>
+                                								
+                                <inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.705893519" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
                                 							
                             </tool>
                             							
-                            <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.1649467943" name="MCU G++ Compiler" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler">
-                                								
-                                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.debuglevel.1505835810" name="Debug level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.debuglevel" useByScannerDiscovery="false" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.debuglevel.value.g3" valueType="enumerated"/>
-                                								
-                                <option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.optimization.level.1592436347" name="Optimization level" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.optimization.level" useByScannerDiscovery="false"/>
-                                								
-                                <inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.1171670869" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp"/>
-                                							
-                            </tool>
+                            <tool id="cdt.managedbuild.tool.gnu.cross.c.linker.297394587" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker"/>
                             							
-                            <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.39208435" name="MCU GCC Linker" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker"/>
-                            							
-                            <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.1499989069" name="MCU G++ Linker" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker">
+                            <tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.1485218774" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker">
                                 								
-                                <inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.input.45277849" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.linker.input">
+                                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.libs.1216064150" name="Libraries (-l)" superClass="gnu.cpp.link.option.libs" useByScannerDiscovery="false" valueType="libs">
+                                    									
+                                    <listOptionValue builtIn="false" value="gtest_main"/>
+                                    									
+                                    <listOptionValue builtIn="false" value="gtest"/>
+                                    								
+                                </option>
+                                								
+                                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.paths.530562007" name="Library search path (-L)" superClass="gnu.cpp.link.option.paths" useByScannerDiscovery="false" valueType="libPaths">
+                                    									
+                                    <listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/Test/lib/lib}&quot;"/>
+                                    								
+                                </option>
+                                								
+                                <inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.1178079221" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
                                     									
                                     <additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
                                     									
@@ -983,21 +1021,13 @@
                                 							
                             </tool>
                             							
-                            <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.archiver.1222833725" name="MCU GCC Archiver" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.archiver"/>
+                            <tool id="cdt.managedbuild.tool.gnu.cross.archiver.587758608" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
                             							
-                            <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.size.1409603338" name="MCU Size" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.size"/>
-                            							
-                            <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objdump.listfile.1864616818" name="MCU Output Converter list file" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objdump.listfile"/>
-                            							
-                            <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.hex.1663131225" name="MCU Output Converter Hex" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.hex"/>
-                            							
-                            <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.binary.1488220281" name="MCU Output Converter Binary" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.binary"/>
-                            							
-                            <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.verilog.218686771" name="MCU Output Converter Verilog" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.verilog"/>
-                            							
-                            <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.srec.1970540003" name="MCU Output Converter Motorola S-rec" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.srec"/>
-                            							
-                            <tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.symbolsrec.557220813" name="MCU Output Converter Motorola S-rec with symbols" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.objcopy.symbolsrec"/>
+                            <tool id="cdt.managedbuild.tool.gnu.cross.assembler.386664857" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+                                								
+                                <inputType id="cdt.managedbuild.tool.gnu.assembler.input.39041064" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+                                							
+                            </tool>
                             						
                         </toolChain>
                         					
@@ -1005,11 +1035,11 @@
                     					
                     <sourceEntries>
                         						
-                        <entry excluding="BME280/|Barometer.cpp|IMU.cpp|StandardI2CDriver.cpp|FastI2CDriver.cpp|BNO055/|SensorAcquisition.cpp" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="Application/HostBoard/Src/Sensors"/>
+                        <entry excluding="BME280/|BNO055/|Barometer.cpp|FastI2CDriver.cpp|IMU.cpp|SensorAcquisition.cpp|StandardI2CDriver.cpp" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="Application/HostBoard/Src/Sensors"/>
                         						
-                        <entry excluding="xbee.cpp|telemetry_receiving.cpp" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="Application/HostBoard/Src/telemetry"/>
+                        <entry excluding="state_machine.cpp|state_estimation.c" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="Application/HostBoard/Src/misc"/>
                         						
-                        <entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="Test/googletest/googletest/scripts/fused_gtest/gtest"/>
+                        <entry excluding="telemetry_receiving.cpp|xbee.cpp" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="Application/HostBoard/Src/telemetry"/>
                         					
                     </sourceEntries>
                     				
@@ -1060,6 +1090,12 @@
         </configuration>
         		
         <configuration configurationName="blah"/>
+        		
+        <configuration configurationName="Test2">
+            			
+            <resource resourceType="PROJECT" workspacePath="/BellaLui"/>
+            		
+        </configuration>
         	
     </storageModule>
     	
@@ -1101,7 +1137,31 @@
             		
         </scannerConfigBuildInfo>
         		
+        <scannerConfigBuildInfo instanceId="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.2009857519;com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.2009857519.;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.116598407;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.input.c.2013690331">
+            			
+            <autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+            		
+        </scannerConfigBuildInfo>
+        		
         <scannerConfigBuildInfo instanceId="fr.ac6.managedbuild.config.gnu.cross.exe.debug.509694695;fr.ac6.managedbuild.config.gnu.cross.exe.debug.509694695.;cdt.managedbuild.tool.gnu.cross.cpp.compiler.1591734592;cdt.managedbuild.tool.gnu.cpp.compiler.input.794442983">
+            			
+            <autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+            		
+        </scannerConfigBuildInfo>
+        		
+        <scannerConfigBuildInfo instanceId="fr.ac6.managedbuild.config.gnu.cross.exe.debug.736238141;fr.ac6.managedbuild.config.gnu.cross.exe.debug.736238141.;fr.ac6.managedbuild.tool.gnu.cross.c.compiler.924285222;fr.ac6.managedbuild.tool.gnu.cross.c.compiler.input.c.486774252">
+            			
+            <autodiscovery enabled="false" problemReportingEnabled="true" selectedProfileId=""/>
+            		
+        </scannerConfigBuildInfo>
+        		
+        <scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.1136125961;cdt.managedbuild.config.gnu.cross.exe.debug.1136125961.;cdt.managedbuild.tool.gnu.cross.cpp.compiler.51403174;cdt.managedbuild.tool.gnu.cpp.compiler.input.705893519">
+            			
+            <autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+            		
+        </scannerConfigBuildInfo>
+        		
+        <scannerConfigBuildInfo instanceId="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.2009857519;com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.2009857519.;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.1649467943;com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.1171670869">
             			
             <autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
             		
@@ -1113,9 +1173,9 @@
             		
         </scannerConfigBuildInfo>
         		
-        <scannerConfigBuildInfo instanceId="fr.ac6.managedbuild.config.gnu.cross.exe.debug.736238141;fr.ac6.managedbuild.config.gnu.cross.exe.debug.736238141.;fr.ac6.managedbuild.tool.gnu.cross.c.compiler.924285222;fr.ac6.managedbuild.tool.gnu.cross.c.compiler.input.c.486774252">
+        <scannerConfigBuildInfo instanceId="cdt.managedbuild.config.gnu.cross.exe.debug.1136125961;cdt.managedbuild.config.gnu.cross.exe.debug.1136125961.;cdt.managedbuild.tool.gnu.cross.c.compiler.1613999135;cdt.managedbuild.tool.gnu.c.compiler.input.169481984">
             			
-            <autodiscovery enabled="false" problemReportingEnabled="true" selectedProfileId=""/>
+            <autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
             		
         </scannerConfigBuildInfo>
         	

--- a/SW4STM32/BellaLui/.settings/language.settings.xml
+++ b/SW4STM32/BellaLui/.settings/language.settings.xml
@@ -13,7 +13,7 @@
             			
             <provider copy-of="extension" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser"/>
             			
-            <provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-1264231040679759076" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+            <provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-1702762713762295368" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
                 				
                 <language-scope id="org.eclipse.cdt.core.gcc"/>
                 				
@@ -37,7 +37,7 @@
             			
             <provider copy-of="extension" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser"/>
             			
-            <provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-1264231040679759076" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+            <provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-1702762713762295368" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
                 				
                 <language-scope id="org.eclipse.cdt.core.gcc"/>
                 				
@@ -49,7 +49,7 @@
         	
     </configuration>
     	
-    <configuration id="com.st.stm32cube.ide.mcu.gnu.managedbuild.config.exe.debug.2009857519" name="Testing">
+    <configuration id="cdt.managedbuild.config.gnu.cross.exe.debug.1136125961" name="Testing">
         		
         <extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
             			
@@ -59,9 +59,7 @@
             			
             <provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
             			
-            <provider copy-of="extension" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser"/>
-            			
-            <provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-1302176406283911550" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+            <provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="false" env-hash="1118345241794350227" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
                 				
                 <language-scope id="org.eclipse.cdt.core.gcc"/>
                 				

--- a/SW4STM32/BellaLui/Application/HostBoard/Inc/Sensors/DataStructures.h
+++ b/SW4STM32/BellaLui/Application/HostBoard/Inc/Sensors/DataStructures.h
@@ -16,8 +16,8 @@ struct Vector {
 };
 
 struct IMUData {
-	Vector accel;
-	Vector gyro;
+	struct Vector accel;
+	struct Vector gyro;
 };
 
 

--- a/SW4STM32/BellaLui/Application/HostBoard/Inc/Sensors/RemoteSensor.h
+++ b/SW4STM32/BellaLui/Application/HostBoard/Inc/Sensors/RemoteSensor.h
@@ -28,14 +28,14 @@ private:
 template<class T>
 bool RemoteSensor<T>::load() {
 	dataPtr = nullptr;
-	ready = true;
+	this->ready = true;
 	return true;
 }
 
 template<class T>
 bool RemoteSensor<T>::unload() {
 	dataPtr = nullptr;
-	ready = false;
+	this->ready = false;
 	return true;
 }
 
@@ -47,7 +47,7 @@ void RemoteSensor<T>::onDataReception(T data) {
 
 template<class T>
 bool RemoteSensor<T>::fetch(T* data) {
-	if(!ready)
+	if(!this->ready)
 		return false;
 
 	if(dataPtr != nullptr) {

--- a/SW4STM32/BellaLui/Application/HostBoard/Inc/can_transmission.h
+++ b/SW4STM32/BellaLui/Application/HostBoard/Inc/can_transmission.h
@@ -99,6 +99,11 @@ typedef struct
 #define MAX_BOARD_ID 8 // used to implement redundant info in CAN_handling
 #define MAX_BOARD_NUMBER (MAX_BOARD_ID+1)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 void CAN_Config(uint32_t id);
 void can_setFrame(uint32_t data, uint8_t data_id, uint32_t timestamp);
 void can_addMsg(CAN_msg msg);
@@ -106,6 +111,10 @@ uint32_t can_msgPending();
 CAN_msg can_readBuffer();
 
 uint8_t get_board_id();
+
+#ifdef __cplusplus
+}
+#endif
 
 
 #endif /* CAN_COMMUNICATION_H_ */

--- a/SW4STM32/BellaLui/Application/HostBoard/Inc/misc/common.h
+++ b/SW4STM32/BellaLui/Application/HostBoard/Inc/misc/common.h
@@ -8,10 +8,6 @@
 #ifndef INCLUDE_COMMON_H_
 #define INCLUDE_COMMON_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <misc/datastructs.h>
 #include <stm32f4xx_hal.h>
 
@@ -25,11 +21,9 @@ extern TIM_HandleTypeDef htim7;
  * States declaration
  */
 
-static const char *state_names[] = { "Sleeping", "Calibrating", "Idle",
-		"Fill valve open", "Fill valve closed", "Purge valve open", "Hose disconnected",
-		"Lift-off", "Coast", "Primary event", "Secondary event", "Touchdown" };
 
 #define NUM_STATES 12
+
 
 enum State {
 	STATE_SLEEP,
@@ -50,27 +44,10 @@ enum Warning {
 	EVENT, WARNING_MOTOR_PRESSURE
 };
 
-volatile uint32_t flight_status;
-volatile float airbrakes_angle;
-extern volatile float air_speed_state_estimate, altitude_estimate;
 
-volatile enum State current_state;
-volatile uint32_t liftoff_time;
-
-volatile uint32_t currentImuSeqNumber;
-volatile uint32_t currentBaroSeqNumber;
-volatile uint32_t currentBaroTimestamp;
-
-extern IMU_data IMU_buffer[CIRC_BUFFER_SIZE]; // defined in CAN_handling.c
-extern BARO_data BARO_buffer[CIRC_BUFFER_SIZE];
-
-static inline IMU_data* getCurrentIMU_data() {
-	return &IMU_buffer[currentImuSeqNumber % CIRC_BUFFER_SIZE];
-}
-
-static inline BARO_data* getCurrentBARO_data() {
-	return &BARO_buffer[currentBaroSeqNumber % CIRC_BUFFER_SIZE];
-}
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 static inline void uint8ToFloat(uint8_t *uint8Ptr, float *floatPtr) {
 	uint8_t *floatAsUintPtr = (uint8_t*) floatPtr;

--- a/SW4STM32/BellaLui/Application/HostBoard/Inc/misc/state_machine.h
+++ b/SW4STM32/BellaLui/Application/HostBoard/Inc/misc/state_machine.h
@@ -22,7 +22,7 @@ public:
 	void publishState();
 	void requestState(enum State new_state);
 	void enterState(enum State new_state);
-	enum State getCurrentState();
+	enum State getCurrentState() { return current_state; }
 
 	IMU_data latestIMUData;
 	BARO_data latestBarometerData;

--- a/SW4STM32/BellaLui/Application/HostBoard/Inc/misc/state_machine.h
+++ b/SW4STM32/BellaLui/Application/HostBoard/Inc/misc/state_machine.h
@@ -8,8 +8,33 @@
 #ifndef MISC_STATE_MACHINE_H_
 #define MISC_STATE_MACHINE_H_
 
-void TK_state_machine (void const * argument);
-void TK_state_estimation ();
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "datastructs.h"
+#include "common.h"
+
+class StateMachine {
+public:
+	StateMachine();
+	~StateMachine() {};
+
+	void publishState();
+	void requestState(enum State new_state);
+	void enterState(enum State new_state);
+	enum State getCurrentState();
+
+	IMU_data latestIMUData;
+	BARO_data latestBarometerData;
+
+	bool newIMUData;
+	bool newBarometerData;
+
+	uint32_t liftoffTime;
+
+private:
+	enum State current_state;
+};
 
 
 #endif /* MISC_STATE_MACHINE_H_ */

--- a/SW4STM32/BellaLui/Application/HostBoard/Inc/misc/state_machine_helpers.h
+++ b/SW4STM32/BellaLui/Application/HostBoard/Inc/misc/state_machine_helpers.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#define NO_LIFTOFF_TIME 0
+
 namespace state_machine_helpers {
     // TODO: change to Enum
     const uint8_t state_idle_false_positive = 11;
@@ -24,7 +26,9 @@ namespace state_machine_helpers {
     const uint8_t state_secondary_no_op = 44;
 
 
+    // TODO: discuss use of acceleration_z vs. acceleration norm for this detection
     uint8_t handleIdleState(const uint32_t currentTime, const uint32_t liftoff_time, const float acceleration_z);
+    // TODO: capture TVC's stop motor command for this
     bool handleLiftoffState(const uint32_t currentTime, const uint32_t previousTime);
     uint8_t handleCoastState(const float max_altitude, const float baro_data_altitude, const float baro_data_base_altitude, const uint32_t apogee_counter);
     uint8_t handlePrimaryState(const uint32_t currentTime, const uint32_t time_tmp, const float baro_data_altitude, const float baro_data_base_altitude, const uint32_t sec_counter);

--- a/SW4STM32/BellaLui/Application/HostBoard/Inc/misc/state_machine_helpers.h
+++ b/SW4STM32/BellaLui/Application/HostBoard/Inc/misc/state_machine_helpers.h
@@ -1,0 +1,34 @@
+#ifndef MISC_STATE_MACHINE_HELPERS_H_
+#define MISC_STATE_MACHINE_HELPERS_H_
+
+#include <stdint.h>
+
+namespace state_machine_helpers {
+    // TODO: change to Enum
+    const uint8_t state_idle_false_positive = 11;
+    const uint8_t state_idle_liftoff_detected = 12;
+    const uint8_t state_idle_switch_to_liftoff_state = 13;
+
+    const uint8_t state_coast_rocket_is_ascending = 21;
+    const uint8_t state_coast_switch_to_primary_state = 22;
+
+    const uint8_t state_primary_altitude_above_secondary_altitude = 31;
+    const uint8_t state_primary_switch_to_secondary_state = 32;
+
+    const uint8_t state_secondary_altitude_difference_still_large = 41;
+    const uint8_t state_secondary_approaching_touchdown = 42;
+    const uint8_t state_secondary_switch_to_touchdown_state = 43;
+
+
+    uint8_t handleIdleState(const uint32_t currentTime, const uint32_t liftoff_time, const float acceleration_z);
+    bool handleLiftoffState(const uint32_t currentTime, const uint32_t previousTime);
+    uint8_t handleCoastState(const float max_altitude, const float baro_data_altitude, const float baro_data_base_altitude, const uint32_t apogee_counter);
+    uint8_t handlePrimaryState(const uint32_t currentTime, const uint32_t time_tmp, const float baro_data_altitude, const float baro_data_base_altitude, const uint32_t sec_counter);
+    uint8_t handleSecondaryState(const uint32_t currentTime, const uint32_t time_tmp, const bool baro_is_ready, const float baro_data_altitude, const float td_last_alt, const uint32_t td_counter);
+
+    uint8_t newImuDataIsAvailable(const uint32_t currentImuSeqNumber, const uint32_t lastImuSeqNumber);
+    uint8_t newBarometerDataIsAvailable(const uint32_t currentBaroSeqNumber, const uint32_t lastBaroSeqNumber);
+    bool touchdownStateIsReached(const uint32_t currentTime, const uint32_t liftoff_time);
+}
+
+#endif /* MISC_STATE_MACHINE_HELPERS_H_ */

--- a/SW4STM32/BellaLui/Application/HostBoard/Inc/misc/state_machine_helpers.h
+++ b/SW4STM32/BellaLui/Application/HostBoard/Inc/misc/state_machine_helpers.h
@@ -8,16 +8,20 @@ namespace state_machine_helpers {
     const uint8_t state_idle_false_positive = 11;
     const uint8_t state_idle_liftoff_detected = 12;
     const uint8_t state_idle_switch_to_liftoff_state = 13;
+    const uint8_t state_idle_no_op = 14;
 
     const uint8_t state_coast_rocket_is_ascending = 21;
     const uint8_t state_coast_switch_to_primary_state = 22;
+    const uint8_t state_coast_no_op = 23;
 
     const uint8_t state_primary_altitude_above_secondary_altitude = 31;
     const uint8_t state_primary_switch_to_secondary_state = 32;
+    const uint8_t state_primary_no_op = 33;
 
     const uint8_t state_secondary_altitude_difference_still_large = 41;
     const uint8_t state_secondary_approaching_touchdown = 42;
     const uint8_t state_secondary_switch_to_touchdown_state = 43;
+    const uint8_t state_secondary_no_op = 44;
 
 
     uint8_t handleIdleState(const uint32_t currentTime, const uint32_t liftoff_time, const float acceleration_z);

--- a/SW4STM32/BellaLui/Application/HostBoard/Inc/misc/state_manager.h
+++ b/SW4STM32/BellaLui/Application/HostBoard/Inc/misc/state_manager.h
@@ -24,7 +24,6 @@ void onBarometerDataReception(BARO_data data);
 void onStateAcknowledged(enum State newState);
 
 enum State getAvionicsState();
-enum State getAvionicsState();
 int32_t getLiftoffTime();
 
 

--- a/SW4STM32/BellaLui/Application/HostBoard/Inc/misc/state_manager.h
+++ b/SW4STM32/BellaLui/Application/HostBoard/Inc/misc/state_manager.h
@@ -1,0 +1,35 @@
+/*
+ * state_manager.h
+ *
+ *  Created on: 28 Apr 2021
+ *      Author: arion
+ */
+
+#ifndef APPLICATION_HOSTBOARD_INC_MISC_STATE_MANAGER_H_
+#define APPLICATION_HOSTBOARD_INC_MISC_STATE_MANAGER_H_
+
+
+#include "misc/common.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+void TK_state_machine(void const* argument);
+
+void onIMUDataReception(IMU_data data);
+void onBarometerDataReception(BARO_data data);
+void onStateAcknowledged(enum State newState);
+
+enum State getAvionicsState();
+enum State getAvionicsState();
+int32_t getLiftoffTime();
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* APPLICATION_HOSTBOARD_INC_MISC_STATE_MANAGER_H_ */

--- a/SW4STM32/BellaLui/Application/HostBoard/Inc/telemetry/test/datagram_check.hpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Inc/telemetry/test/datagram_check.hpp
@@ -75,7 +75,7 @@ inline void checkCRC(uint8_t *ptr, int size) {
  * Specific functions for verifying each type of datagram
  */
 
-inline void checkTelemetryDatagram(Telemetry_Message *msg, uint32_t ts, uint32_t seq, IMU_data imu, BARO_data baro, float32_t speed, float32_t altitude) {
+inline void checkTelemetryDatagram(Telemetry_Message *msg, uint32_t ts, uint32_t seq, IMU_data imu, BARO_data baro, float speed, float altitude) {
 	int size = 40; //bytes
 
 	ASSERT_EQ(msg->size, TOTAL_DATAGRAM_OVERHEAD + size);
@@ -99,7 +99,7 @@ inline void checkTelemetryDatagram(Telemetry_Message *msg, uint32_t ts, uint32_t
 		checkCRC((uint8_t*) msg->buf, msg->size - CHECKSUM_SIZE);
 }
 
-inline void checkAirbrakesDatagram(Telemetry_Message *msg, uint32_t ts, uint32_t seq, float32_t angle) {
+inline void checkAirbrakesDatagram(Telemetry_Message *msg, uint32_t ts, uint32_t seq, float angle) {
 	int size = 4; //bytes
 
 	ASSERT_EQ(msg->size, TOTAL_DATAGRAM_OVERHEAD + size);
@@ -128,7 +128,7 @@ inline void checkGpsDatagram(Telemetry_Message *msg, uint32_t ts, uint32_t seq, 
 		checkCRC((uint8_t*) msg->buf, msg->size - CHECKSUM_SIZE);
 }
 
-inline void checkStateDatagram(Telemetry_Message *msg, uint32_t ts, uint32_t seq, uint8_t id, float32_t val, uint8_t state) {
+inline void checkStateDatagram(Telemetry_Message *msg, uint32_t ts, uint32_t seq, uint8_t id, float val, uint8_t state) {
 	int size = 6; //bytes
 
 	ASSERT_EQ(msg->size, TOTAL_DATAGRAM_OVERHEAD + size);

--- a/SW4STM32/BellaLui/Application/HostBoard/Inc/threads.h
+++ b/SW4STM32/BellaLui/Application/HostBoard/Inc/threads.h
@@ -57,7 +57,7 @@
 #define BOARD_LED_G (50)
 #define BOARD_LED_B (50)
 #define FLASH_LOGGING
-#define TESTING
+#define TESTING // TODO: not used for now, but check if it's really OK
 #define ROCKET_FSM
 #endif
 

--- a/SW4STM32/BellaLui/Application/HostBoard/Inc/threads.h
+++ b/SW4STM32/BellaLui/Application/HostBoard/Inc/threads.h
@@ -10,7 +10,7 @@
 
 #define OS_STKCHECK
 #define LED
-#define TELEMETRY_BOARD
+#define SENSOR_BOARD
 
 
 #ifdef GPS_BOARD
@@ -57,8 +57,8 @@
 #define BOARD_LED_G (50)
 #define BOARD_LED_B (50)
 #define FLASH_LOGGING
+#define TESTING
 #define ROCKET_FSM
-#define KALMAN
 #endif
 
 #ifdef FLASH_DUMP_BOARD
@@ -100,11 +100,15 @@
 #endif
 
 #ifdef ROCKET_FSM
-#include <misc/state_machine.h>
+#include <misc/state_manager.h>
 #endif
 
 #ifdef PRESSURE_MONITORING
 #include <propulsion/pressure_monitor.h>
+#endif
+
+#ifdef TESTING
+#include <Sensors/DataStructures.h>
 #endif
 
 

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/Sensors/AltitudeEstimator.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/Sensors/AltitudeEstimator.cpp
@@ -112,8 +112,6 @@ bool AltitudeEstimator::fetch(AltitudeData* data) {
 	}
 }
 
-#include "debug/console.h"
-
 float AltitudeEstimator::altitudeComputation(float raw_pressure, float raw_temperature) { // Temperature in °C, pressure can have any unit.
 	float altitude1;
 	float altitude2;

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/airbrakes/airbrakes.c
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/airbrakes/airbrakes.c
@@ -10,11 +10,11 @@
 #include "can_reception.h"
 #include "can_transmission.h"
 #include "debug/led.h"
+#include "misc/state_manager.h"
 
 
 #include <stm32f4xx_hal.h>
 #include <cmsis_os.h>
-#include <misc/common.h>
 #include <stdbool.h>
 
 #define AB_PERIOD_MS (50)
@@ -42,13 +42,15 @@ void TK_ab_controller(void const *argument) {
 	osDelay(1000);
 
 	while (true) {
-		if (current_state < STATE_COAST) {
+		enum State currentState = getAvionicsState();
+
+		if (currentState < STATE_COAST) {
 			full_close();
 			led_set_TK_rgb(led_AB_id, 0, 10, 0);
-		} else if (current_state == STATE_COAST) {
+		} else if (currentState == STATE_COAST) {
 			command_aerobrake_controller(can_getAltitude(), can_getSpeed());
 			led_set_TK_rgb(led_AB_id, 50, 50, 50);
-		} else if (current_state >= STATE_PRIMARY) {
+		} else if (currentState >= STATE_PRIMARY) {
 			full_close();
 			led_set_TK_rgb(led_AB_id, 50, 50, 0);
 		}

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/can_reception.c
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/can_reception.c
@@ -358,7 +358,7 @@ void TK_can_reader() {
 
 		end_profiler();
 
-		osDelay(10);
+		sync_logic(1);
 	}
 }
 

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/kalman/gps_ekf.c
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/kalman/gps_ekf.c
@@ -25,7 +25,7 @@
 #include "debug/profiler.h"
 #include "debug/console.h"
 #include "debug/monitor.h"
-#include "misc/common.h"
+#include "misc/state_manager.h"
 
 
 #include <stdbool.h>
@@ -260,7 +260,7 @@ void TK_kalman() {
 				exit_monitor(KALMAN_MONITOR);
 			}
 
-			if(altitude > altimax && liftoff_time != 0) {
+			if(altitude > altimax && getAvionicsState() >= STATE_LIFTOFF) {
 				if(altimax_time == 0) {
 					rocket_log("Initial altitude is %dmm at %dms\n", altitude, HAL_GetTick());
 				}
@@ -270,7 +270,7 @@ void TK_kalman() {
 			}
 
 			if(HAL_GetTick() - altimax_time > 5000 && altimax_time != 0) {
-				rocket_log("Maximal altitude of %dmm reached after %dms\n", altimax, altimax_time - liftoff_time);
+				rocket_log("Maximal altitude of %dmm reached after %dms\n", altimax, altimax_time - getLiftoffTime());
 				altimax_time = 0;
 			}
 

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/misc/Test/state_machine_tests.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/misc/Test/state_machine_tests.cpp
@@ -5,12 +5,12 @@
 
 TEST(StateMachineTests, ShouldStayInLiftoffStateDuringMotorBurnTime){
     //ASSERT_EQ(handleLiftoffState(ROCKET_CST_MOTOR_BURNTIME - 10, 0), STATE_LIFTOFF);
-    ASSERT_EQ(state_machine_helpers::handleLiftoffState(ROCKET_CST_MOTOR_BURNTIME - 10, 0), false);
+    ASSERT_FALSE(state_machine_helpers::handleLiftoffState(ROCKET_CST_MOTOR_BURNTIME - 10, 0));
 }
 
 TEST(StateMachineTests, ShouldSwitchFromLiftoffToCoastStateAfterMotorBurnTime){
     //ASSERT_EQ(handleLiftoffState(ROCKET_CST_MOTOR_BURNTIME + 10, 0), STATE_COAST);
-    ASSERT_EQ(state_machine_helpers::handleLiftoffState(ROCKET_CST_MOTOR_BURNTIME + 10, 0), true);
+    ASSERT_TRUE(state_machine_helpers::handleLiftoffState(ROCKET_CST_MOTOR_BURNTIME + 10, 0));
 }
 
 TEST(StateMachineTests, ShouldGetCorrectImuStatus){
@@ -55,7 +55,7 @@ TEST(StateMachineTests, ShouldGetCorrectIdleStateStatus){
 
     currentTime = liftoffTime + 300;
     state_idle_status = state_machine_helpers::handleIdleState(currentTime, liftoffTime, acceleration_z);
-    EXPECT_EQ(state_idle_status, 0);
+    EXPECT_EQ(state_idle_status, state_machine_helpers::state_idle_no_op);
 
     liftoffTime = 0;
     state_idle_status = state_machine_helpers::handleIdleState(currentTime, liftoffTime, acceleration_z);
@@ -75,11 +75,11 @@ TEST(StateMachineTests, ShouldGetCorrectPrimaryStateStatus){
     float baro_data_altitude = 120;
 
     uint8_t state_primary_status = state_machine_helpers::handlePrimaryState(currentTime,  time_tmp, baro_data_altitude, baro_data_base_altitude, sec_counter);
-    EXPECT_EQ(state_primary_status, 0);
+    EXPECT_EQ(state_primary_status, state_primary_no_op);
 
     sec_counter = SECONDARY_BUFFER_SIZE;
     state_primary_status = state_machine_helpers::handlePrimaryState(currentTime,  time_tmp, baro_data_altitude, baro_data_base_altitude, sec_counter);
-    EXPECT_EQ(state_primary_status, 0);
+    EXPECT_EQ(state_primary_status, state_primary_no_op);
 
     currentTime = time_tmp + APOGEE_MUTE_TIME + 1;
     state_primary_status = state_machine_helpers::handlePrimaryState(currentTime,  time_tmp, baro_data_altitude, baro_data_base_altitude, sec_counter);
@@ -87,7 +87,7 @@ TEST(StateMachineTests, ShouldGetCorrectPrimaryStateStatus){
 
     sec_counter = SECONDARY_BUFFER_SIZE - 1;
     state_primary_status = state_machine_helpers::handlePrimaryState(currentTime,  time_tmp, baro_data_altitude, baro_data_base_altitude, sec_counter);
-    EXPECT_EQ(state_primary_status, 0);
+    EXPECT_EQ(state_primary_status, state_primary_no_op);
 
     sec_counter = SECONDARY_BUFFER_SIZE;
 
@@ -112,11 +112,11 @@ TEST(StateMachineTests, ShouldGetCorrectSecondaryStateStatus){
     float td_last_alt = 130;
 
     uint8_t state_secondary_status = state_machine_helpers::handleSecondaryState(currentTime, time_tmp, baro_is_ready, baro_data_altitude, td_last_alt, td_counter);
-    EXPECT_EQ(state_secondary_status, 0);
+    EXPECT_EQ(state_secondary_status, state_secondary_no_op);
 
     baro_is_ready = true;
     state_secondary_status = state_machine_helpers::handleSecondaryState(currentTime, time_tmp, baro_is_ready, baro_data_altitude, td_last_alt, td_counter);
-    EXPECT_EQ(state_secondary_status, 0);
+    EXPECT_EQ(state_secondary_status, state_secondary_no_op);
 
     currentTime = time_tmp + TOUCHDOWN_DELAY_TIME + 10;
     state_secondary_status = state_machine_helpers::handleSecondaryState(currentTime, time_tmp, baro_is_ready, baro_data_altitude, td_last_alt, td_counter);

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/misc/Test/state_machine_tests.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/misc/Test/state_machine_tests.cpp
@@ -75,11 +75,11 @@ TEST(StateMachineTests, ShouldGetCorrectPrimaryStateStatus){
     float baro_data_altitude = 120;
 
     uint8_t state_primary_status = state_machine_helpers::handlePrimaryState(currentTime,  time_tmp, baro_data_altitude, baro_data_base_altitude, sec_counter);
-    EXPECT_EQ(state_primary_status, state_primary_no_op);
+    EXPECT_EQ(state_primary_status, state_machine_helpers::state_primary_no_op);
 
     sec_counter = SECONDARY_BUFFER_SIZE;
     state_primary_status = state_machine_helpers::handlePrimaryState(currentTime,  time_tmp, baro_data_altitude, baro_data_base_altitude, sec_counter);
-    EXPECT_EQ(state_primary_status, state_primary_no_op);
+    EXPECT_EQ(state_primary_status, state_machine_helpers::state_primary_no_op);
 
     currentTime = time_tmp + APOGEE_MUTE_TIME + 1;
     state_primary_status = state_machine_helpers::handlePrimaryState(currentTime,  time_tmp, baro_data_altitude, baro_data_base_altitude, sec_counter);
@@ -87,7 +87,7 @@ TEST(StateMachineTests, ShouldGetCorrectPrimaryStateStatus){
 
     sec_counter = SECONDARY_BUFFER_SIZE - 1;
     state_primary_status = state_machine_helpers::handlePrimaryState(currentTime,  time_tmp, baro_data_altitude, baro_data_base_altitude, sec_counter);
-    EXPECT_EQ(state_primary_status, state_primary_no_op);
+    EXPECT_EQ(state_primary_status, state_machine_helpers::state_primary_no_op);
 
     sec_counter = SECONDARY_BUFFER_SIZE;
 
@@ -112,11 +112,11 @@ TEST(StateMachineTests, ShouldGetCorrectSecondaryStateStatus){
     float td_last_alt = 130;
 
     uint8_t state_secondary_status = state_machine_helpers::handleSecondaryState(currentTime, time_tmp, baro_is_ready, baro_data_altitude, td_last_alt, td_counter);
-    EXPECT_EQ(state_secondary_status, state_secondary_no_op);
+    EXPECT_EQ(state_secondary_status, state_machine_helpers::state_secondary_no_op);
 
     baro_is_ready = true;
     state_secondary_status = state_machine_helpers::handleSecondaryState(currentTime, time_tmp, baro_is_ready, baro_data_altitude, td_last_alt, td_counter);
-    EXPECT_EQ(state_secondary_status, state_secondary_no_op);
+    EXPECT_EQ(state_secondary_status, state_machine_helpers::state_secondary_no_op);
 
     currentTime = time_tmp + TOUCHDOWN_DELAY_TIME + 10;
     state_secondary_status = state_machine_helpers::handleSecondaryState(currentTime, time_tmp, baro_is_ready, baro_data_altitude, td_last_alt, td_counter);

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/misc/Test/state_machine_tests.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/misc/Test/state_machine_tests.cpp
@@ -37,7 +37,7 @@ TEST(StateMachineTests, ShouldReachTouchdownStateAfterFiveMinutes){
     EXPECT_FALSE(state_machine_helpers::touchdownStateIsReached(currentTime, liftoffTime));
     currentTime = 8*60*1000;
     EXPECT_TRUE(state_machine_helpers::touchdownStateIsReached(currentTime, liftoffTime));
-    liftoffTime = 0;
+    liftoffTime = NO_LIFTOFF_TIME;
     EXPECT_FALSE(state_machine_helpers::touchdownStateIsReached(currentTime, liftoffTime));
 }
 
@@ -57,7 +57,7 @@ TEST(StateMachineTests, ShouldGetCorrectIdleStateStatus){
     state_idle_status = state_machine_helpers::handleIdleState(currentTime, liftoffTime, acceleration_z);
     EXPECT_EQ(state_idle_status, state_machine_helpers::state_idle_no_op);
 
-    liftoffTime = 0;
+    liftoffTime = NO_LIFTOFF_TIME;
     state_idle_status = state_machine_helpers::handleIdleState(currentTime, liftoffTime, acceleration_z);
     EXPECT_EQ(state_idle_status, state_machine_helpers::state_idle_liftoff_detected);
 }

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/misc/Test/state_machine_tests.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/misc/Test/state_machine_tests.cpp
@@ -1,0 +1,140 @@
+#include "misc/state_machine_helpers.h"
+
+#include "gtest/gtest.h"
+#include "misc/rocket_constants.h"
+
+TEST(StateMachineTests, ShouldStayInLiftoffStateDuringMotorBurnTime){
+    //ASSERT_EQ(handleLiftoffState(ROCKET_CST_MOTOR_BURNTIME - 10, 0), STATE_LIFTOFF);
+    ASSERT_EQ(state_machine_helpers::handleLiftoffState(ROCKET_CST_MOTOR_BURNTIME - 10, 0), false);
+}
+
+TEST(StateMachineTests, ShouldSwitchFromLiftoffToCoastStateAfterMotorBurnTime){
+    //ASSERT_EQ(handleLiftoffState(ROCKET_CST_MOTOR_BURNTIME + 10, 0), STATE_COAST);
+    ASSERT_EQ(state_machine_helpers::handleLiftoffState(ROCKET_CST_MOTOR_BURNTIME + 10, 0), true);
+}
+
+TEST(StateMachineTests, ShouldGetCorrectImuStatus){
+    uint8_t imuIsReady = state_machine_helpers::newImuDataIsAvailable(4, 3);
+    EXPECT_EQ(imuIsReady, 1);
+    imuIsReady = state_machine_helpers::newImuDataIsAvailable(3,3);
+    EXPECT_EQ(imuIsReady, 0);
+    imuIsReady = state_machine_helpers::newImuDataIsAvailable(2,3);
+    EXPECT_EQ(imuIsReady, 0);
+}
+
+TEST(StateMachineTests, ShouldGetCorrectBarometerStatus){
+    uint8_t barometerIsReady = state_machine_helpers::newBarometerDataIsAvailable(4, 3);
+    EXPECT_EQ(barometerIsReady, 1);
+    barometerIsReady = state_machine_helpers::newBarometerDataIsAvailable(3,3);
+    EXPECT_EQ(barometerIsReady, 0);
+    barometerIsReady = state_machine_helpers::newBarometerDataIsAvailable(2,3);
+    EXPECT_EQ(barometerIsReady, 0);
+}
+
+TEST(StateMachineTests, ShouldReachTouchdownStateAfterFiveMinutes){
+    uint32_t currentTime = 2*60*1000;
+    uint32_t liftoffTime = 1*60*1000;
+    EXPECT_FALSE(state_machine_helpers::touchdownStateIsReached(currentTime, liftoffTime));
+    currentTime = 8*60*1000;
+    EXPECT_TRUE(state_machine_helpers::touchdownStateIsReached(currentTime, liftoffTime));
+    liftoffTime = 0;
+    EXPECT_FALSE(state_machine_helpers::touchdownStateIsReached(currentTime, liftoffTime));
+}
+
+TEST(StateMachineTests, ShouldGetCorrectIdleStateStatus){
+    uint32_t currentTime = 2*60*1000;
+    uint32_t liftoffTime = 1*60*1000;
+    float acceleration_z = 1;
+
+    uint8_t state_idle_status = state_machine_helpers::handleIdleState(currentTime, liftoffTime, acceleration_z);
+    EXPECT_EQ(state_idle_status, state_machine_helpers::state_idle_false_positive);
+
+    acceleration_z = 2.1;
+    state_idle_status = state_machine_helpers::handleIdleState(currentTime, liftoffTime, acceleration_z);
+    EXPECT_EQ(state_idle_status, state_machine_helpers::state_idle_switch_to_liftoff_state);
+
+    currentTime = liftoffTime + 300;
+    state_idle_status = state_machine_helpers::handleIdleState(currentTime, liftoffTime, acceleration_z);
+    EXPECT_EQ(state_idle_status, 0);
+
+    liftoffTime = 0;
+    state_idle_status = state_machine_helpers::handleIdleState(currentTime, liftoffTime, acceleration_z);
+    EXPECT_EQ(state_idle_status, state_machine_helpers::state_idle_liftoff_detected);
+}
+
+TEST(StateMachineTests, ShouldGetCorrectPrimaryStateStatus){
+    // ROCKET_CST_REC_SECONDARY_ALT == 150
+    // APOGEE_MUTE_TIME == 5000
+    // SECONDARY_BUFFER_SIZE == 5
+    uint32_t currentTime = 1*60*1000 + 60;
+    uint32_t time_tmp = 1*60*1000;
+
+    uint32_t sec_counter = 1; 
+
+    float baro_data_base_altitude = 100;
+    float baro_data_altitude = 120;
+
+    uint8_t state_primary_status = state_machine_helpers::handlePrimaryState(currentTime,  time_tmp, baro_data_altitude, baro_data_base_altitude, sec_counter);
+    EXPECT_EQ(state_primary_status, 0);
+
+    sec_counter = SECONDARY_BUFFER_SIZE;
+    state_primary_status = state_machine_helpers::handlePrimaryState(currentTime,  time_tmp, baro_data_altitude, baro_data_base_altitude, sec_counter);
+    EXPECT_EQ(state_primary_status, 0);
+
+    currentTime = time_tmp + APOGEE_MUTE_TIME + 1;
+    state_primary_status = state_machine_helpers::handlePrimaryState(currentTime,  time_tmp, baro_data_altitude, baro_data_base_altitude, sec_counter);
+    EXPECT_EQ(state_primary_status, state_machine_helpers::state_primary_switch_to_secondary_state);
+
+    sec_counter = SECONDARY_BUFFER_SIZE - 1;
+    state_primary_status = state_machine_helpers::handlePrimaryState(currentTime,  time_tmp, baro_data_altitude, baro_data_base_altitude, sec_counter);
+    EXPECT_EQ(state_primary_status, 0);
+
+    sec_counter = SECONDARY_BUFFER_SIZE;
+
+    baro_data_altitude = baro_data_base_altitude + ROCKET_CST_REC_SECONDARY_ALT + 1;
+    state_primary_status = state_machine_helpers::handlePrimaryState(currentTime,  time_tmp, baro_data_altitude, baro_data_base_altitude, sec_counter); 
+    EXPECT_EQ(state_primary_status, state_machine_helpers::state_primary_altitude_above_secondary_altitude);
+}
+
+TEST(StateMachineTests, ShouldGetCorrectSecondaryStateStatus){
+    // TOUCHDOWN_BUFFER_SIZE == 5
+    // TOUCHDOWN_DELAY_TIME == 2000
+    // TOUCHDOWN_ALT_DIFF == 2
+    uint32_t currentTime = 1*60*1000 + 60;
+    uint32_t time_tmp = 1*60*1000;
+
+    uint32_t sec_counter = 1; 
+
+    bool baro_is_ready = false;
+    float baro_data_altitude = 120;
+
+    uint8_t td_counter = 1;
+    float td_last_alt = 130;
+
+    uint8_t state_secondary_status = state_machine_helpers::handleSecondaryState(currentTime, time_tmp, baro_is_ready, baro_data_altitude, td_last_alt, td_counter);
+    EXPECT_EQ(state_secondary_status, 0);
+
+    baro_is_ready = true;
+    state_secondary_status = state_machine_helpers::handleSecondaryState(currentTime, time_tmp, baro_is_ready, baro_data_altitude, td_last_alt, td_counter);
+    EXPECT_EQ(state_secondary_status, 0);
+
+    currentTime = time_tmp + TOUCHDOWN_DELAY_TIME + 10;
+    state_secondary_status = state_machine_helpers::handleSecondaryState(currentTime, time_tmp, baro_is_ready, baro_data_altitude, td_last_alt, td_counter);
+    EXPECT_EQ(state_secondary_status, state_machine_helpers::state_secondary_altitude_difference_still_large);
+    
+    baro_data_altitude = td_last_alt + TOUCHDOWN_ALT_DIFF + 1;
+    state_secondary_status = state_machine_helpers::handleSecondaryState(currentTime, time_tmp, baro_is_ready, baro_data_altitude, td_last_alt, td_counter);
+    EXPECT_EQ(state_secondary_status, state_machine_helpers::state_secondary_altitude_difference_still_large);
+
+    baro_data_altitude = td_last_alt + TOUCHDOWN_ALT_DIFF;
+    state_secondary_status = state_machine_helpers::handleSecondaryState(currentTime, time_tmp, baro_is_ready, baro_data_altitude, td_last_alt, td_counter);
+    EXPECT_EQ(state_secondary_status, state_machine_helpers::state_secondary_approaching_touchdown);
+
+    td_counter = TOUCHDOWN_BUFFER_SIZE - 1;
+    state_secondary_status = state_machine_helpers::handleSecondaryState(currentTime, time_tmp, baro_is_ready, baro_data_altitude, td_last_alt, td_counter);
+    EXPECT_EQ(state_secondary_status, state_machine_helpers::state_secondary_approaching_touchdown);
+
+    td_counter = TOUCHDOWN_BUFFER_SIZE;
+    state_secondary_status = state_machine_helpers::handleSecondaryState(currentTime, time_tmp, baro_is_ready, baro_data_altitude, td_last_alt, td_counter);
+    EXPECT_EQ(state_secondary_status, state_machine_helpers::state_secondary_switch_to_touchdown_state);
+}

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/misc/Test/state_machine_tests.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/misc/Test/state_machine_tests.cpp
@@ -62,6 +62,37 @@ TEST(StateMachineTests, ShouldGetCorrectIdleStateStatus){
     EXPECT_EQ(state_idle_status, state_machine_helpers::state_idle_liftoff_detected);
 }
 
+TEST(StateMachineTests, ShouldGetCorrectCoastStateStatus){
+	// APOGEE_BUFFER_SIZE == 100
+	// APOGEE_ALT_DIFF == 1
+	// ROCKET_CST_MIN_TRIG_AGL == 300
+	float max_altitude = 100;
+	float baro_data_altitude = 200;
+	float baro_data_base_altitude = 0;
+	uint32_t apogee_counter = 0;
+
+	uint8_t state_coast_status = state_machine_helpers::handleCoastState(max_altitude, baro_data_altitude, baro_data_base_altitude, apogee_counter);
+	EXPECT_EQ(state_coast_status, state_machine_helpers::state_coast_rocket_is_ascending);
+
+	max_altitude = 400;
+	baro_data_altitude = 350;
+	state_coast_status = state_machine_helpers::handleCoastState(max_altitude, baro_data_altitude, baro_data_base_altitude, apogee_counter);
+	EXPECT_EQ(state_coast_status, state_machine_helpers::state_coast_no_op);
+
+	apogee_counter = APOGEE_BUFFER_SIZE;
+	baro_data_altitude = max_altitude - APOGEE_ALT_DIFF;
+	state_coast_status = state_machine_helpers::handleCoastState(max_altitude, baro_data_altitude, baro_data_base_altitude, apogee_counter);
+	EXPECT_EQ(state_coast_status, state_machine_helpers::state_coast_no_op);
+
+	baro_data_altitude = max_altitude - APOGEE_ALT_DIFF - 1;
+	state_coast_status = state_machine_helpers::handleCoastState(max_altitude, baro_data_altitude, baro_data_base_altitude, apogee_counter);
+	EXPECT_EQ(state_coast_status, state_machine_helpers::state_coast_switch_to_primary_state);
+
+	baro_data_altitude = ROCKET_CST_MIN_TRIG_AGL;
+	state_coast_status = state_machine_helpers::handleCoastState(max_altitude, baro_data_altitude, baro_data_base_altitude, apogee_counter);
+	EXPECT_EQ(state_coast_status, state_machine_helpers::state_coast_no_op);
+}
+
 TEST(StateMachineTests, ShouldGetCorrectPrimaryStateStatus){
     // ROCKET_CST_REC_SECONDARY_ALT == 150
     // APOGEE_MUTE_TIME == 5000

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine.c
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine.c
@@ -179,7 +179,7 @@ void TK_state_machine(void const *argument) {
 
 			uint8_t state_secondary_status = state_machine_helpers::handleSecondaryState(HAL_GetTick(), time_tmp, baroIsReady, baro_data_altitude, td_last_alt, td_counter);
 
-			if(state_primary_status != 0){
+			if(state_secondary_status != state_secondary_no_op){
 				time_tmp = HAL_GetTick();
 				td_last_alt = baro_data->altitude;
 

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine.cpp
@@ -34,14 +34,6 @@ StateMachine::StateMachine() :
 		newIMUData(false),
 		newBarometerData(false),
 		liftoffTime(-1) {
-	enterState(STATE_CALIBRATION);
-}
-
-
-void StateMachine::publishState() {
-	#ifdef XBEE
-	telemetrySendState(HAL_GetTick(), EVENT, 0, this->current_state);
-	#endif
 }
 
 
@@ -88,7 +80,7 @@ void TK_state_machine(void const *argument) {
 
 	// State Machine initialization
 	// Hyp: rocket is on rail waiting for lift-off
-	fsm.enterState(STATE_CALIBRATION);
+	fsm.requestState(STATE_CALIBRATION);
 
 
 	// State Machine main task loop
@@ -118,8 +110,6 @@ void TK_state_machine(void const *argument) {
 
 
 		enum State currentState = fsm.getCurrentState();
-
-		fsm.publishState();
 
 		if(enter_monitor(STATE_MONITOR) && currentState >= 0 && currentState < NUM_STATES) {
 			rocket_log(" Time: %dms\x1b[K\n", HAL_GetTick());

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine.cpp
@@ -33,7 +33,8 @@ StateMachine::StateMachine() :
 		latestBarometerData({0}),
 		newIMUData(false),
 		newBarometerData(false),
-		liftoffTime(NO_LIFTOFF_TIME) {
+		liftoffTime(NO_LIFTOFF_TIME),
+		current_state(STATE_SLEEP) {
 }
 
 

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine.cpp
@@ -33,7 +33,7 @@ StateMachine::StateMachine() :
 		latestBarometerData({0}),
 		newIMUData(false),
 		newBarometerData(false),
-		liftoffTime(-1) {
+		liftoffTime(NO_LIFTOFF_TIME) {
 }
 
 
@@ -74,7 +74,7 @@ void TK_state_machine(void const *argument) {
 	uint32_t td_counter = 0;
 
 	uint32_t flight_status = 0;
-	uint32_t preliminary_liftoff_time = 0;
+	uint32_t preliminary_liftoff_time = NO_LIFTOFF_TIME;
 
 	// TODO: Set low package data rate
 
@@ -140,7 +140,7 @@ void TK_state_machine(void const *argument) {
 				uint8_t state_idle_status = state_machine_helpers::handleIdleState(currentTime, preliminary_liftoff_time, abs_fl32(imu_data.acceleration.z));
 
 				if(state_idle_status == state_machine_helpers::state_idle_false_positive){
-					preliminary_liftoff_time = 0;
+					preliminary_liftoff_time = NO_LIFTOFF_TIME;
 					time_tmp = 0;
 				}
 				else if (state_idle_status == state_machine_helpers::state_idle_liftoff_detected){
@@ -148,7 +148,7 @@ void TK_state_machine(void const *argument) {
 					time_tmp = currentTime; // Start timer to estimate motor burn out
 				}
 				else if(state_idle_status == state_machine_helpers::state_idle_switch_to_liftoff_state) {
-					fsm.liftoffTime = preliminary_liftoff_time;
+					fsm.liftoffTime = preliminary_liftoff_time; // TODO: there is a problem here, the state request does not encompass this
 					fsm.requestState(STATE_LIFTOFF); // Switch to lift-off state
 				}
 			}

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine.cpp
@@ -64,7 +64,7 @@ void TK_state_machine(void const *argument) {
 
 	// Declare sensor variables
 	IMU_data imu_data = {0};
-	BARO_data baro_data = {0};
+	BARO_data baro_data = {0}; // TODO: correctly manage "base_altitude"
 	uint8_t imuIsReady = 0, baroIsReady = 0;
 
 	// Declare apogee detection variables
@@ -92,6 +92,7 @@ void TK_state_machine(void const *argument) {
 	while(true) {
 		sync_logic(10);
 
+		// TODO: check if race condition is possible here?
 		imuIsReady = fsm.newIMUData;
 
 		if (imuIsReady) {

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine.cpp
@@ -59,7 +59,7 @@ void TK_state_machine(void const *argument) {
 	osDelay(2000);
 
 	// Declare time variable
-	uint32_t time_tmp = 0;
+	uint32_t time_tmp = 0; // TODO: rename this
 
 	// Declare sensor variables
 	IMU_data imu_data = {0};

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine.cpp
@@ -11,6 +11,7 @@
 #include "misc/rocket_constants.h"
 #include "debug/monitor.h"
 #include "debug/console.h"
+#include "telemetry/telemetry_sending.h"
 #include "sync.h"
 
 #include <cmsis_os.h>
@@ -18,18 +19,55 @@
 #include <stm32f4xx_hal.h>
 
 
-void TK_state_machine(void const *argument) {
-	current_state = STATE_SLEEP;
+static const char *state_names[] = { "Sleeping", "Calibrating", "Idle",
+		"Fill valve open", "Fill valve closed", "Purge valve open", "Hose disconnected",
+		"Lift-off", "Coast", "Primary event", "Secondary event", "Touchdown" };
 
+
+
+static StateMachine fsm;
+
+
+StateMachine::StateMachine() :
+		latestIMUData({0}),
+		latestBarometerData({0}),
+		newIMUData(false),
+		newBarometerData(false),
+		liftoffTime(-1) {
+	enterState(STATE_CALIBRATION);
+}
+
+
+void StateMachine::publishState() {
+	#ifdef XBEE
+	telemetrySendState(HAL_GetTick(), EVENT, 0, this->current_state);
+	#endif
+}
+
+
+void StateMachine::requestState(enum State newState) {
+	can_setFrame(newState, DATA_ID_STATE, HAL_GetTick());
+}
+
+void StateMachine::enterState(enum State new_state) {
+	if(new_state >= 0 && new_state < NUM_STATES) {
+		this->current_state = new_state;
+		rocket_log("Entered %s state\r\n", state_names[new_state]);
+	} else {
+		rocket_log("Attempt was made to enter an inconsistent state (%d)\r\n", new_state);
+	}
+}
+
+
+void TK_state_machine(void const *argument) {
 	osDelay(2000);
 
 	// Declare time variable
 	uint32_t time_tmp = 0;
 
 	// Declare sensor variables
-	IMU_data *imu_data = 0;
-	BARO_data *baro_data = 0;
-	uint32_t lastImuSeqNumber = 0, lastBaroSeqNumber = 0;
+	IMU_data imu_data = {0};
+	BARO_data baro_data = {0};
 	uint8_t imuIsReady = 0, baroIsReady = 0;
 
 	// Declare apogee detection variables
@@ -43,56 +81,65 @@ void TK_state_machine(void const *argument) {
 	float td_last_alt = 0;
 	uint32_t td_counter = 0;
 
+	uint32_t flight_status = 0;
+	uint32_t preliminary_liftoff_time = 0;
+
 	// TODO: Set low package data rate
 
 	// State Machine initialization
 	// Hyp: rocket is on rail waiting for lift-off
-	current_state = STATE_CALIBRATION;
+	fsm.enterState(STATE_CALIBRATION);
 
-	rocket_log("Entered calibration state\r\n");
 
 	// State Machine main task loop
 	while(true) {
 		sync_logic(10);
-		can_setFrame(current_state, DATA_ID_STATE, HAL_GetTick());
 
-		imuIsReady = state_machine_helpers::newImuDataIsAvailable(currentImuSeqNumber, lastImuSeqNumber);
+		imuIsReady = fsm.newIMUData;
+
 		if (imuIsReady) {
 			// Update accelerometer reading
-			imu_data = getCurrentIMU_data();
-			lastImuSeqNumber = currentImuSeqNumber;
+			imu_data = fsm.latestIMUData;
+			fsm.newIMUData = false;
 		}
 
-		baroIsReady = state_machine_helpers::newBarometerDataIsAvailable(currentBaroSeqNumber, lastBaroSeqNumber);
+		baroIsReady = fsm.newBarometerData;
+
 		if (baroIsReady) {
 			// Update barometer reading
-			baro_data = getCurrentBARO_data();
-			lastBaroSeqNumber = currentBaroSeqNumber;
+			baro_data = fsm.latestBarometerData;
+			fsm.newBarometerData = false;
 		}
 
-		if(state_machine_helpers::touchdownStateIsReached(HAL_GetTick(), liftoff_time)){
-			current_state = STATE_TOUCHDOWN;
+		if(state_machine_helpers::touchdownStateIsReached(HAL_GetTick(), preliminary_liftoff_time)){
+			fsm.requestState(STATE_TOUCHDOWN);
 			flight_status = 40; // TODO: flight_status numbers should be defined as consts
 		}
 
-		if(enter_monitor(STATE_MONITOR) && current_state < NUM_STATES) {
+
+		enum State currentState = fsm.getCurrentState();
+
+		fsm.publishState();
+
+		if(enter_monitor(STATE_MONITOR) && currentState >= 0 && currentState < NUM_STATES) {
 			rocket_log(" Time: %dms\x1b[K\n", HAL_GetTick());
-			rocket_log(" Current state: %s\x1b[K\n", state_names[current_state]);
-			if (baro_data != 0) {
-				rocket_log(" Altitude: %d\x1b[K\n", (int32_t) (1000 * (baro_data->altitude - baro_data->base_altitude)));
+			rocket_log(" Current state: %s\x1b[K\n", state_names[currentState]);
+
+			if(baroIsReady) {
+				rocket_log(" Altitude: %d\x1b[K\n", (int32_t) (1000 * (baro_data.altitude - baro_data.base_altitude)));
 			} else {
 				rocket_log(" Altitude unavailable\x1b[K\n");
 			}
+
 			exit_monitor(STATE_MONITOR);
 		}
 
 		// State Machine
-		switch (current_state) {
+		switch (currentState) {
 
 		case STATE_CALIBRATION: {
 			if (baroIsReady) {
-				current_state = STATE_IDLE;
-				rocket_log("Entered idle state\r\n");
+				fsm.requestState(STATE_IDLE);
 			}
 			break;
 		}
@@ -100,19 +147,19 @@ void TK_state_machine(void const *argument) {
 		case STATE_IDLE: {
 			if (imuIsReady) {
 				const uint32_t currentTime = HAL_GetTick();
-				uint8_t state_idle_status = state_machine_helpers::handleIdleState(currentTime, liftoff_time, abs_fl32(imu_data->acceleration.z));
+				uint8_t state_idle_status = state_machine_helpers::handleIdleState(currentTime, preliminary_liftoff_time, abs_fl32(imu_data.acceleration.z));
 
 				if(state_idle_status == state_machine_helpers::state_idle_false_positive){
-					liftoff_time = 0;
+					preliminary_liftoff_time = 0;
 					time_tmp = 0;
 				}
 				else if (state_idle_status == state_machine_helpers::state_idle_liftoff_detected){
-					liftoff_time = currentTime;
+					preliminary_liftoff_time = currentTime;
 					time_tmp = currentTime; // Start timer to estimate motor burn out
 				}
-				else if(state_idle_status == state_machine_helpers::state_idle_switch_to_liftoff_state){
-					current_state = STATE_LIFTOFF; // Switch to lift-off state
-					rocket_log("Liftoff triggered\r\n");
+				else if(state_idle_status == state_machine_helpers::state_idle_switch_to_liftoff_state) {
+					fsm.liftoffTime = preliminary_liftoff_time;
+					fsm.requestState(STATE_LIFTOFF); // Switch to lift-off state
 				}
 			}
 			break;
@@ -120,10 +167,11 @@ void TK_state_machine(void const *argument) {
 
 		case STATE_LIFTOFF: {
 			flight_status = 10; // TODO: flight_status numbers should be defined as consts
+
 			if(state_machine_helpers::handleLiftoffState(HAL_GetTick(), time_tmp)){
-				current_state = STATE_COAST;
-				rocket_log("Coast state triggered\r\n");
+				fsm.requestState(STATE_COAST);
 			}
+
 			break;
 		}
 
@@ -132,19 +180,18 @@ void TK_state_machine(void const *argument) {
 
 			// compute apogee triggers for altitude
 			if (baroIsReady) {
-				uint8_t state_coast_status = state_machine_helpers::handleCoastState(max_altitude, baro_data->altitude, baro_data->base_altitude, apogee_counter);
+				uint8_t state_coast_status = state_machine_helpers::handleCoastState(max_altitude, baro_data.altitude, baro_data.base_altitude, apogee_counter);
 
 				if(state_coast_status == state_machine_helpers::state_coast_rocket_is_ascending){
-					max_altitude = baro_data->altitude; // if a new maximum altitude is found, this means the rocket is going up					
+					max_altitude = baro_data.altitude; // if a new maximum altitude is found, this means the rocket is going up
 					apogee_counter = 0; // The descending measurement counter is thus set to zero
 				}
 				else{
 					++apogee_counter; // if the rocket isn't rising then it is descending, thus the number of descending measurements are counted
 					if(state_coast_status == state_machine_helpers::state_coast_switch_to_primary_state){
 						time_tmp = HAL_GetTick(); // save time to mute sensors while ejection occures
-						current_state = STATE_PRIMARY; // switch to primary descent phase
+						fsm.requestState(STATE_PRIMARY); // switch to primary descent phase
 						flight_status = 30; // TODO: flight_status numbers should be defined as consts
-						rocket_log("Primary event state triggered\r\n");
 					}
 				}
 			}
@@ -153,7 +200,7 @@ void TK_state_machine(void const *argument) {
 
 		case STATE_PRIMARY: {
 			if (baroIsReady) {
-				uint8_t state_primary_status = state_machine_helpers::handlePrimaryState(HAL_GetTick(), time_tmp, baro_data->altitude, baro_data->base_altitude, sec_counter);
+				uint8_t state_primary_status = state_machine_helpers::handlePrimaryState(HAL_GetTick(), time_tmp, baro_data.altitude, baro_data.base_altitude, sec_counter);
 
 				if(state_primary_status == state_machine_helpers::state_primary_altitude_above_secondary_altitude){
 					sec_counter = 0;
@@ -162,10 +209,9 @@ void TK_state_machine(void const *argument) {
 					++sec_counter; // if the measured altitude is lower than the trigger altitude, start counting
 					if(state_primary_status == state_machine_helpers::state_primary_switch_to_secondary_state){
 						time_tmp = HAL_GetTick(); // save current time to start differed touchdown detection rate
-						current_state = STATE_SECONDARY; // switch to secondary recovery phase
-						td_last_alt = baro_data->altitude; // save altitude measurement for touchdown detection
+						fsm.requestState(STATE_SECONDARY); // switch to secondary recovery phase
+						td_last_alt = baro_data.altitude; // save altitude measurement for touchdown detection
 						flight_status = 35; // TODO: flight_status numbers should be defined as consts
-						rocket_log("Secondary event state triggered\r\n");
 					}
 				}
 			}
@@ -173,15 +219,13 @@ void TK_state_machine(void const *argument) {
 		}
 
 		case STATE_SECONDARY: {
-			uint8_t counterTdTrig = 0;
-
-			const float baro_data_altitude = baroIsReady ? baro_data->altitude : -1;
+			const float baro_data_altitude = baroIsReady ? baro_data.altitude : -1;
 
 			uint8_t state_secondary_status = state_machine_helpers::handleSecondaryState(HAL_GetTick(), time_tmp, baroIsReady, baro_data_altitude, td_last_alt, td_counter);
 
-			if(state_secondary_status != state_secondary_no_op){
+			if(state_secondary_status != state_machine_helpers::state_secondary_no_op){
 				time_tmp = HAL_GetTick();
-				td_last_alt = baro_data->altitude;
+				td_last_alt = baro_data.altitude;
 
 				if(state_secondary_status == state_machine_helpers::state_secondary_altitude_difference_still_large){
 					td_counter = 0;
@@ -189,10 +233,9 @@ void TK_state_machine(void const *argument) {
 				else{
 					++td_counter;
 					if(state_secondary_status == state_machine_helpers::state_secondary_switch_to_touchdown_state){
-						current_state = STATE_TOUCHDOWN;
+						fsm.requestState(STATE_TOUCHDOWN);
 						flight_status = 40; // TODO: flight_status numbers should be defined as consts
 						// TODO: Set telemetry data rate to low
-						rocket_log("Touchdown state triggered\r\n");
 					}
 				}
 			}
@@ -202,7 +245,32 @@ void TK_state_machine(void const *argument) {
 
 		case STATE_TOUCHDOWN:
 			break;
-		}
 
+		default:
+			// Error handling
+			break;
+		}
 	}
+}
+
+extern "C" void onIMUDataReception(IMU_data data) {
+	fsm.latestIMUData = data;
+	fsm.newIMUData = true;
+}
+
+extern "C" void onBarometerDataReception(BARO_data data) {
+	fsm.latestBarometerData = data;
+	fsm.newBarometerData = true;
+}
+
+extern "C" void onStateAcknowledged(enum State newState) {
+	fsm.enterState(newState);
+}
+
+extern "C" enum State getAvionicsState() {
+	return fsm.getCurrentState();
+}
+
+extern "C" int32_t getLiftoffTime() {
+	return fsm.liftoffTime;
 }

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine.cpp
@@ -48,6 +48,10 @@ void StateMachine::enterState(enum State new_state) {
 	} else {
 		rocket_log("Attempt was made to enter an inconsistent state (%d)\r\n", new_state);
 	}
+	// workaround to update liftoff time which is not propagated in the state request (TODO)
+	if(new_state == STATE_LIFTOFF && this->liftoffTime == NO_LIFTOFF_TIME) {
+		this->liftoffTime = HAL_GetTick();
+	}
 }
 
 
@@ -148,7 +152,7 @@ void TK_state_machine(void const *argument) {
 					time_tmp = currentTime; // Start timer to estimate motor burn out
 				}
 				else if(state_idle_status == state_machine_helpers::state_idle_switch_to_liftoff_state) {
-					fsm.liftoffTime = preliminary_liftoff_time; // TODO: there is a problem here, the state request does not encompass this
+					fsm.liftoffTime = preliminary_liftoff_time; // if liftoff time is null, it will be set when entering the lift-off state
 					fsm.requestState(STATE_LIFTOFF); // Switch to lift-off state
 				}
 			}

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine_helpers.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine_helpers.cpp
@@ -1,0 +1,110 @@
+#include "misc/state_machine_helpers.h"
+
+#include "misc/rocket_constants.h"
+
+namespace state_machine_helpers {
+
+    uint8_t handleIdleState(const uint32_t currentTime, const uint32_t liftoff_time, const float acceleration_z) {
+        bool liftoffAccelTrig = acceleration_z > ROCKET_CST_LIFTOFF_TRIG_ACCEL; //Compute lift-off triggers for acceleration
+
+        if(liftoff_time == 0 && liftoffAccelTrig){
+            return state_idle_liftoff_detected;
+        }
+        else if (liftoff_time != 0) {
+            if(!liftoffAccelTrig){
+                return state_idle_false_positive;
+            }
+            //already detected the acceleration trigger. now we need the trigger for at least 1000ms before trigerring the liftoff.
+            else if (currentTime - liftoff_time > LIFTOFF_DETECTION_DELAY) {
+                return state_idle_switch_to_liftoff_state;
+            }
+        }
+        return 0;
+    }
+
+    bool handleLiftoffState(const uint32_t currentTime, const uint32_t previousTime) {
+		// determine motor burn-out based on lift-off detection
+		if ((currentTime - previousTime) > ROCKET_CST_MOTOR_BURNTIME) {
+		    //return STATE_COAST; // switch to coast state
+            return true;
+        }
+        //return STATE_LIFTOFF;
+        return false;
+    }
+
+    uint8_t handleCoastState(const float max_altitude, const float baro_data_altitude, const float baro_data_base_altitude, const uint32_t apogee_counter) {
+        // update the maximum altitude detected up to this point
+        if (max_altitude < baro_data_altitude) {					
+            return state_coast_rocket_is_ascending; 
+        } 
+        else {
+            // if the number of measurements exceeds a certain value (basic noise filtering) then the altitude trigger based on the counter is enabled
+            bool counterAltTrig = apogee_counter+1 > APOGEE_BUFFER_SIZE;
+            // since the rocket is then supposed to be descending, the trigger waits for an altitude offset greater than the one defined to occure before triggering the state change
+            bool diffAltTrig = (max_altitude - baro_data_altitude) > APOGEE_ALT_DIFF; 
+            bool minAltTrig = ((baro_data_altitude - baro_data_base_altitude) > ROCKET_CST_MIN_TRIG_AGL);
+
+            if (minAltTrig && counterAltTrig && diffAltTrig) {
+                return state_coast_switch_to_primary_state;
+            }
+        }
+
+        return 0;        
+    }
+
+    uint8_t handlePrimaryState(const uint32_t currentTime, const uint32_t time_tmp, const float baro_data_altitude, const float baro_data_base_altitude, const uint32_t sec_counter) {
+        // update the minimum altitude detected up to this point
+        if ((baro_data_altitude - baro_data_base_altitude) > ROCKET_CST_REC_SECONDARY_ALT) {
+            return state_primary_altitude_above_secondary_altitude; // As long as the measured altitude is above the secondary recovery event altitude, keep buffer counter to 0
+        } 
+        else {
+            bool counterSecTrig = sec_counter+1 > SECONDARY_BUFFER_SIZE; // if more than a given amount of measurements are below the secondary recovery altitude, toggle the state trigger
+            
+            bool sensorMuteTimeTrig = (currentTime - time_tmp) > APOGEE_MUTE_TIME; // check that some time has passed since the detection of the apogee before triggering the secondary recovery event
+
+            if (counterSecTrig && sensorMuteTimeTrig)
+            {
+                return state_primary_switch_to_secondary_state;
+            }
+        }
+
+        return 0;
+    }
+
+    float abs_fl32(float v) { // copied in order to avoid including common.h
+	    return (v >= 0) ? v : -v;
+    }
+
+    uint8_t handleSecondaryState(const uint32_t currentTime, const uint32_t time_tmp, const bool baro_is_ready, const float baro_data_altitude, const float td_last_alt, const uint32_t td_counter){
+        // if a given time has passed since the last time the check was done, do the check
+        if (((currentTime - time_tmp) > TOUCHDOWN_DELAY_TIME) && baro_is_ready) {
+
+                if (abs_fl32(baro_data_altitude - td_last_alt) <= TOUCHDOWN_ALT_DIFF){
+
+                    if (td_counter+1 > TOUCHDOWN_BUFFER_SIZE){
+                        return state_machine_helpers::state_secondary_switch_to_touchdown_state;
+                    }
+
+                    return state_machine_helpers::state_secondary_approaching_touchdown;
+                }
+
+                return state_machine_helpers::state_secondary_altitude_difference_still_large;
+            }
+
+        return 0;
+    }
+
+    uint8_t newImuDataIsAvailable(const uint32_t currentImuSeqNumber, const uint32_t lastImuSeqNumber) {
+        return currentImuSeqNumber > lastImuSeqNumber;
+    }
+
+    uint8_t newBarometerDataIsAvailable(const uint32_t currentBaroSeqNumber, const uint32_t lastBaroSeqNumber){
+        return currentBaroSeqNumber > lastBaroSeqNumber;
+    }
+
+    bool touchdownStateIsReached(const uint32_t currentTime, const uint32_t liftoff_time){
+        const bool timeExceedsFiveMinutes = ((int32_t) currentTime - (int32_t) liftoff_time) > 5 * 60 * 1000;
+        return liftoff_time != 0 && timeExceedsFiveMinutes;
+    }
+
+}

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine_helpers.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine_helpers.cpp
@@ -7,10 +7,10 @@ namespace state_machine_helpers {
     uint8_t handleIdleState(const uint32_t currentTime, const uint32_t liftoff_time, const float acceleration_z) {
         bool liftoffAccelTrig = acceleration_z > ROCKET_CST_LIFTOFF_TRIG_ACCEL; //Compute lift-off triggers for acceleration
 
-        if(liftoff_time == 0 && liftoffAccelTrig){
+        if(liftoff_time == NO_LIFTOFF_TIME && liftoffAccelTrig){
             return state_idle_liftoff_detected;
         }
-        else if (liftoff_time != 0) {
+        else if (liftoff_time != NO_LIFTOFF_TIME) {
             if(!liftoffAccelTrig){
                 return state_idle_false_positive;
             }
@@ -104,7 +104,7 @@ namespace state_machine_helpers {
 
     bool touchdownStateIsReached(const uint32_t currentTime, const uint32_t liftoff_time){
         const bool timeExceedsFiveMinutes = ((int32_t) currentTime - (int32_t) liftoff_time) > 5 * 60 * 1000;
-        return liftoff_time != 0 && timeExceedsFiveMinutes;
+        return liftoff_time != NO_LIFTOFF_TIME && timeExceedsFiveMinutes;
     }
 
 }

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine_helpers.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/misc/state_machine_helpers.cpp
@@ -19,7 +19,7 @@ namespace state_machine_helpers {
                 return state_idle_switch_to_liftoff_state;
             }
         }
-        return 0;
+        return state_idle_no_op;
     }
 
     bool handleLiftoffState(const uint32_t currentTime, const uint32_t previousTime) {
@@ -49,7 +49,7 @@ namespace state_machine_helpers {
             }
         }
 
-        return 0;        
+        return state_coast_no_op;        
     }
 
     uint8_t handlePrimaryState(const uint32_t currentTime, const uint32_t time_tmp, const float baro_data_altitude, const float baro_data_base_altitude, const uint32_t sec_counter) {
@@ -68,7 +68,7 @@ namespace state_machine_helpers {
             }
         }
 
-        return 0;
+        return state_primary_no_op;
     }
 
     float abs_fl32(float v) { // copied in order to avoid including common.h
@@ -82,16 +82,16 @@ namespace state_machine_helpers {
                 if (abs_fl32(baro_data_altitude - td_last_alt) <= TOUCHDOWN_ALT_DIFF){
 
                     if (td_counter+1 > TOUCHDOWN_BUFFER_SIZE){
-                        return state_machine_helpers::state_secondary_switch_to_touchdown_state;
+                        return state_secondary_switch_to_touchdown_state;
                     }
 
-                    return state_machine_helpers::state_secondary_approaching_touchdown;
+                    return state_secondary_approaching_touchdown;
                 }
 
-                return state_machine_helpers::state_secondary_altitude_difference_still_large;
+                return state_secondary_altitude_difference_still_large;
             }
 
-        return 0;
+        return state_secondary_no_op;
     }
 
     uint8_t newImuDataIsAvailable(const uint32_t currentImuSeqNumber, const uint32_t lastImuSeqNumber) {

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/telemetry/test/datagram_builder_test.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/telemetry/test/datagram_builder_test.cpp
@@ -93,7 +93,7 @@ TEST(TelemetryTest, DatagramCreation_Telemetry) {
 	uint32_t ts = 1234;
 	IMU_data imu = { { 1.1, 2.2, 3.3 }, { 4.4, 5.5, 6.6 } };
 	BARO_data baro = { 15.5, 1.05, 5024.6, 0, 0 };
-	float32_t speed = 10.1, altitude = baro.altitude;
+	float speed = 10.1, altitude = baro.altitude;
 
 	Telemetry_Message *msg = createTelemetryDatagram(ts, &imu, &baro, speed, altitude);
 
@@ -102,7 +102,7 @@ TEST(TelemetryTest, DatagramCreation_Telemetry) {
 
 TEST(TelemetryTest, DatagramCreation_Airbrakes) {
 	uint32_t ts = 2345;
-	float32_t angle = 12.05;
+	float angle = 12.05;
 
 	Telemetry_Message *msg = createAirbrakesDatagram(ts, angle);
 
@@ -121,7 +121,7 @@ TEST(TelemetryTest, DatagramCreation_GPS) {
 TEST(TelemetryTest, DatagramCreation_State) {
 	uint32_t ts = 4567;
 	uint8_t id = 2;
-	float32_t val = 10.1;
+	float val = 10.1;
 	uint8_t state = 0x08;
 
 	Telemetry_Message *msg = createStateDatagram(ts, id, val, state);

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/telemetry/test/telemetry_sending_test.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/telemetry/test/telemetry_sending_test.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 #include "telemetry/telemetry_sending.h"
+#include "telemetry/queue/Queue.h"
 #include "telemetry/queue/StlMessageQueue.h"
 #include "telemetry/test/datagram_check.hpp"
 #include "Embedded/can.h"
@@ -25,11 +26,11 @@ TEST(TelemetryTest, TelemetrySending_NoQueue) {
 	BARO_data baro = { 15.5, 1.05, 5024.6, 0, 0 };
 	EXPECT_FALSE(telemetrySendBaro(ts, baro));
 
-	float32_t angle = 12.05;
+	float angle = 12.05;
 	EXPECT_FALSE(telemetrySendAirbrakesAngle(ts, angle));
 
 	uint8_t id = 1;
-	float32_t val = 10.1;
+	float val = 10.1;
 	uint8_t state = 0x08;
 	EXPECT_FALSE(telemetrySendState(ts, id, val, state));
 
@@ -114,13 +115,13 @@ TEST(TelemetryTest, TelemetrySending_Airbrakes) {
 
 	// first push is successful
 	uint32_t ts1 = 3456;
-	float32_t angle1 = 12.05;
+	float angle1 = 12.05;
 	EXPECT_TRUE(telemetrySendAirbrakesAngle(ts1, angle1));
 	EXPECT_EQ(queue.count(), 1);
 
 	// second push comes too early -> refused
 	uint32_t ts2 = 2345;
-	float32_t angle2 = 13.05;
+	float angle2 = 13.05;
 	usleep(AB_TIMEMIN * 1000 / 2);
 	EXPECT_FALSE(telemetrySendAirbrakesAngle(ts2, angle2));
 	EXPECT_EQ(queue.count(), 1);
@@ -148,7 +149,7 @@ TEST(TelemetryTest, TelemetrySending_State) {
 	// first push is successful
 	uint32_t ts1 = 4567;
 	uint8_t id1 = 1;
-	float32_t val1 = 10.1;
+	float val1 = 10.1;
 	uint8_t state1 = 0x08;
 	EXPECT_TRUE(telemetrySendState(ts1, id1, val1, state1));
 	EXPECT_EQ(queue.count(), 1);
@@ -156,7 +157,7 @@ TEST(TelemetryTest, TelemetrySending_State) {
 	// second push comes too early -> refused
 	uint32_t ts2 = 5678;
 	uint8_t id2 = 2;
-	float32_t val2 = 20.2;
+	float val2 = 20.2;
 	uint8_t state2 = 0x09;
 	usleep(STATE_TIMEMIN * 1000 / 2);
 	EXPECT_FALSE(telemetrySendState(ts2, id2, val2, state2));

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/telemetry/xbee.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/telemetry/xbee.cpp
@@ -19,6 +19,7 @@
 #include "debug/board_io.h"
 #include "debug/led.h"
 #include "misc/datastructs.h"
+#include "misc/state_manager.h"
 
 #include <stdint.h>
 #include <stm32f4xx_hal.h>
@@ -114,6 +115,9 @@ void TK_xBeeTransmit(const void *args) {
 		start_profiler(1);
 
 		uint32_t elapsed = HAL_GetTick() - packetStartTime;
+
+		telemetrySendState(HAL_GetTick(), EVENT, 0, getAvionicsState());
+
 
 		if((currentXbeeTxBufPos > 0) && (elapsed) > XBEE_SEND_FRAME_TIMEOUT_MS) {
 			//timeout reached and buffer not empty, sending frame whatever the content

--- a/SW4STM32/BellaLui/Application/HostBoard/Src/telemetry/xbee.cpp
+++ b/SW4STM32/BellaLui/Application/HostBoard/Src/telemetry/xbee.cpp
@@ -116,6 +116,7 @@ void TK_xBeeTransmit(const void *args) {
 
 		uint32_t elapsed = HAL_GetTick() - packetStartTime;
 
+		// send state - this is auto-rate-limited inside the function
 		telemetrySendState(HAL_GetTick(), EVENT, 0, getAvionicsState());
 
 

--- a/SW4STM32/BellaLui/Makefile
+++ b/SW4STM32/BellaLui/Makefile
@@ -22,7 +22,11 @@ BIN_DIR= ./bin
 
 SENSORS_INC_DIR = $(INC_DIR)/Sensors
 SENSORS_SRC_DIR = $(SRC_DIR)/Sensors
-SENSORS_TESTS_DIR = ./Application/HostBoard/Src/Sensors/Test
+SENSORS_TESTS_DIR = $(SENSORS_SRC_DIR)/Test
+
+MISC_INC_DIR = $(INC_DIR)/misc
+MISC_SRC_DIR = $(SRC_DIR)/misc
+MISC_TESTS_DIR = $(MISC_SRC_DIR)/Test
 
 # Where to find gtest_main.cc.
 GTEST_MAIN_CC = $(GOOGLETEST_DIR)/src/gtest_main.cc
@@ -37,9 +41,11 @@ CXX = g++
 CXXFLAGS += -g -std=c++1y
 
 all : $(BIN_DIR)/sensor_tests
+	$(BIN_DIR)/state_machine_tests
 
 check : all
-	./$(BIN_DIR)/sensor_tests
+	./$(BIN_DIR)/sensor_tests \
+	./$(BIN_DIR)/state_machine_tests
 
 fuse_gtest : $(GOOGLETEST_DIR)/scripts/fuse_gtest_files.py
 	python3 $(GOOGLETEST_DIR)/scripts/fuse_gtest_files.py $(FUSED_GTEST_DIR)
@@ -85,5 +91,17 @@ SensorTest.o : $(SENSORS_TESTS_DIR)/SensorTest.cpp \
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(SENSORS_TESTS_DIR)/SensorTest.cpp
 
 $(BIN_DIR)/sensor_tests : MockBarometer.o MockIMU.o UnbiasedIMU.o CSV.o UnbiasedBarometer.o AltitudeSimulator.o AltitudeEstimator.o SensorTest.o gtest-all.o gtest_main.o
+	mkdir -p $(BIN_DIR)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ -o $@
+
+
+state_machine_helpers.o : $(MISC_SRC_DIR)/state_machine_helpers.cpp $(MISC_INC_DIR)/state_machine_helpers.h
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(MISC_SRC_DIR)/state_machine_helpers.cpp
+
+state_machine_tests.o : $(MISC_TESTS_DIR)/state_machine_tests.cpp \
+                     $(MISC_INC_DIR)/state_machine_helpers.h $(FUSED_GTEST_H)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(MISC_TESTS_DIR)/state_machine_tests.cpp
+
+$(BIN_DIR)/state_machine_tests : state_machine_helpers.o state_machine_tests.o gtest-all.o gtest_main.o
 	mkdir -p $(BIN_DIR)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ -o $@


### PR DESCRIPTION
Here's the pull request for the state machine refactoring + unit tests.
The basic design is that I extracted the logic from each state to a helper function in state_machine_helpers and unit tested all the helper functions.
However, the global variables are still updated in state_machine.c; I think a more drastic refactoring will be needed to clean things up further.

One issue is that I couldn't personally compile state_machine.c, so if you could compile it and maybe run it in some way to make sure everything is fine that would be great.
Another thing is that the unit tests are basically written in accordance to the current logic, we should therefore check if the unit tests themselves make sense, and that the logic is sensible since I think with this refactoring everything is clearer.